### PR TITLE
Feature/validate action

### DIFF
--- a/bin/bigpanda-splunk-defaults
+++ b/bin/bigpanda-splunk-defaults
@@ -21,9 +21,19 @@ function exit_nicely {
     exit $1
 }
 
-function already_configured {
-    echo "INFO:  BigPanda integration is already configured"
-    exit_nicely 0
+function enable_action {
+    # Enable the script action by default for all alerts (existing and new)
+    if ! grep -i --silent "action.script\s*=" $CONFIGURATION_FILE; then
+        echo "INFO:  Enabling action.script by default for all alerts"
+        echo "action.script = 1" >> $CONFIGURATION_FILE
+    else
+        if grep -i --silent "action.script\s*=\s*1" $CONFIGURATION_FILE; then
+            echo "INFO:  action.script is already enabled."
+        else
+            echo "INFO:  Enabling action.script by default for all alerts"
+            sed -i.bak '/^action.script *= *0$/ s/0/1/' $CONFIGURATION_FILE
+        fi
+    fi
 }
 
 function configure_script_filename {
@@ -71,39 +81,35 @@ done
 SPLUNK_HOME=${SPLUNK_HOME:-/opt/splunk}
 CONFIGURATION_FILE=$SPLUNK_HOME/etc/system/local/savedsearches.conf
 
-echo "INFO:  Splunk home is $SPLUNK_HOME. Configuring BigPanda in $CONFIGURATION_FILE"
+echo "INFO:  Splunk home is $SPLUNK_HOME"
+if [ ! -d "$SPLUNK_HOME" ]; then
+    echo "ERROR:  Splunk home directory does not exist at path $SPLUNK_HOME"
+    exit 1
+fi
+echo "INFO:  Configuring BigPanda in $CONFIGURATION_FILE"
 
 if [ ! -f $CONFIGURATION_FILE ]; then
     write_configuration_file
     chown splunk:splunk $CONFIGURATION_FILE
     chmod 0600 $CONFIGURATION_FILE
 else
-
-    # Enable the script action by default for all alerts (existing and new)
-    if ! grep -i --silent "action.script\s*=" $CONFIGURATION_FILE; then
-        echo "INFO:  Enabling action.script by default for all alerts"
-        echo "action.script = 1" >> $CONFIGURATION_FILE
-    else
-        if grep -i --silent "action.script\s*=\s*1" $CONFIGURATION_FILE; then
-            echo "INFO:  action.script is already enabled."
-        else
-            echo "INFO:  Enabling action.script by default for all alerts"
-            sed -i.bak '/^action.script *= *0$/ s/0/1/' $CONFIGURATION_FILE
-        fi
-    fi
-
+    
     # Make sure action.script.filename was not already configured
     if grep -i --silent "action.script.filename" $CONFIGURATION_FILE; then
         # Make sure we're not grepping our own configuration
         if grep -i --silent "action.script.filename\s*=.*bigpanda.*" $CONFIGURATION_FILE; then
-            already_configured
+            echo "INFO:  BigPanda integration is already configured"
+            enable_action
         else
             echo "ERROR:  action.script.filename is already configured. Contact support@bigpanda.io for details on how to configure an existing action script."
             exit_nicely 1
         fi
+    else
+        enable_action
+        configure_script_filename
     fi
 
-    configure_script_filename
+
 
 fi
 

--- a/prepare-build.sh
+++ b/prepare-build.sh
@@ -1,9 +1,6 @@
 #!/bin/bash
 TAG=${TRAVIS_TAG:-"unknown"}
 if [[ "${TAG}" = "unknown" ]]; then
-    TAG=`git describe`
-    if [[ "$?" != "0" ]]; then
-        TAG=`git describe --always`
-    fi
+    TAG=`git describe --always`
 fi
 echo ${TAG} | cut -c 1- > VERSION

--- a/prepare-build.sh
+++ b/prepare-build.sh
@@ -3,7 +3,7 @@ TAG=${TRAVIS_TAG:-"unknown"}
 if [[ "${TAG}" = "unknown" ]]; then
     TAG=`git describe`
     if [[ "$?" != "0" ]]; then
-        TAG="v0.0.0"
+        TAG=`git describe --always`
     fi
 fi
 echo ${TAG} | cut -c 1- > VERSION


### PR DESCRIPTION
@hkariti @erikzaadi  the idea of this fix is to first check whether an action script filename is configured and only then do things like enable it. This in case the user configured an action script but disabled it, in which case we don't want to enable it by accident.
